### PR TITLE
Update source dir

### DIFF
--- a/tardigrade/templates/aws/management/terragrunt.hcl
+++ b/tardigrade/templates/aws/management/terragrunt.hcl
@@ -4,7 +4,7 @@ include {
 }
 
 terraform {
-  source = "../../..//roots/aws/management"
+  source = "../../../..//roots/aws/management"
 }
 
 generate "provider" {

--- a/tardigrade/templates/aws/member/terragrunt.hcl
+++ b/tardigrade/templates/aws/member/terragrunt.hcl
@@ -4,7 +4,7 @@ include {
 }
 
 terraform {
-  source = "../../..//roots/aws/member"
+  source = "../../../..//roots/aws/member"
 }
 
 generate "provider" {


### PR DESCRIPTION
fix issue where terragrunt.hcl nested inside of {accountID}/management does not properly escape to the roots/aws dir. 